### PR TITLE
64bit port

### DIFF
--- a/sources/engine/src/pvr/POD.cpp
+++ b/sources/engine/src/pvr/POD.cpp
@@ -314,8 +314,8 @@ static bool ReadCPODData(
                 if(!src.ReadAfterAlloc(s.pData, nLen)) return false; 
             } 
             else 
-            { 
-                if(!src.Read(s.pData)) return false; 
+            {
+                if(!src.Skip(nLen)) return false;
             }
             break;
 


### PR DESCRIPTION
POD models reader from an old version of PVR SDK is not ready for 64 bit, particularly when interleaved data come into play. Fortunately we don't use the latter so just call reader.Skip()