### PR TITLE
Fix linker warnings. Copy assets directory post-build.

### DIFF
--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -20,7 +20,6 @@ target_compile_definitions(SkyCrasher PRIVATE
                 -DNOMINMAX
 )
 
-
 if(${CMAKE_SIZEOF_VOID_P} STREQUAL "8")
     set(GLEWPATH engine/sdk/OpenGL2/lib/x64)
 else()
@@ -31,4 +30,8 @@ target_link_directories(SkyCrasher PRIVATE ${GLEWPATH})
 
 target_link_libraries(SkyCrasher Game Engine glew32s opengl32)
 
-#add_subdirectory(skycrasher/tools/EffectViewer)
+set(SkyCrasherDir $<TARGET_FILE_DIR:SkyCrasher>)
+
+add_custom_command(TARGET SkyCrasher POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/../assets ${CMAKE_CURRENT_BINARY_DIR}/assets/
+)

--- a/sources/engine/CMakeLists.txt
+++ b/sources/engine/CMakeLists.txt
@@ -207,4 +207,6 @@ target_include_directories(Engine
 target_compile_definitions(Engine PRIVATE
                 -D_CRT_SECURE_NO_WARNINGS
                 -D_UNICODE
+                -DGLEW_STATIC
+                -DNOMINMAX
 )

--- a/sources/skycrasher/game/CMakeLists.txt
+++ b/sources/skycrasher/game/CMakeLists.txt
@@ -137,4 +137,6 @@ target_link_libraries(Game Engine)
 target_compile_definitions(Game PRIVATE
                 -D_CRT_SECURE_NO_WARNINGS
                 -D_UNICODE
+                -DGLEW_STATIC
+                -DNOMINMAX
 )


### PR DESCRIPTION
GLEW_STATIC macro was not defined for all the targets causing linker warnings.
'assets' directory is now copied to the place where executable is expecting it.